### PR TITLE
feat: editor core — canvas, elements, toolbar (#1-#6)

### DIFF
--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -1,0 +1,24 @@
+You are helping a developer start working on a GitHub issue.
+
+## Steps
+
+1. **Ask which issue number** to work on (if not provided as argument: $ARGUMENTS)
+
+2. **Read the issue**: Run `gh issue view <number>` to understand requirements
+
+3. **Create a feature branch**:
+   - Ensure you're on `dev` and it's up to date: `git checkout dev && git pull`
+   - Create branch: `git checkout -b feature/<issue-number>-<short-description>`
+
+4. **Summarize the plan**: Tell the developer:
+   - What the issue requires
+   - Which files need to be created or modified
+   - Any dependencies on other issues
+   - Suggested implementation approach
+
+5. **Do NOT start coding** — wait for the developer to confirm the plan
+
+## Rules
+- Branch naming: `feature/{issue-number}-{short-description}`
+- Always branch from `dev`, never from `main`
+- Always pull latest `dev` before branching

--- a/.claude/commands/submit-pr.md
+++ b/.claude/commands/submit-pr.md
@@ -1,0 +1,25 @@
+You are helping a developer submit a PR for their completed feature branch.
+
+## Steps
+
+1. **Check status**: Run `git status` and `git diff dev...HEAD --stat` to see all changes
+
+2. **Verify build**: Run `bun run build` and `bun run lint` — do NOT proceed if either fails
+
+3. **Update docs**: Run the same steps as `/update-docs` — update changelog.md, project-status.md, and architecture.md if needed. Commit doc changes.
+
+4. **Push branch**: `git push -u origin <current-branch>`
+
+5. **Create PR**:
+   - Base branch: `dev`
+   - Title: concise, under 70 chars, prefixed with `feat:`, `fix:`, or `chore:`
+   - Body: summary bullets, issue references (Closes #X), and test plan checklist
+   - Use: `gh pr create --base dev --title "..." --body "..."`
+
+6. **Report**: Share the PR URL with the developer
+
+## Rules
+- Never create a PR if build or lint fails
+- Always target `dev` branch, never `main`
+- Always include issue references in PR body
+- Always include a test plan

--- a/.claude/commands/update-docs.md
+++ b/.claude/commands/update-docs.md
@@ -1,0 +1,30 @@
+You are updating the project's living documentation after a feature or issue has been completed.
+
+## Steps
+
+1. **Detect what changed**: Run `git diff dev...HEAD --stat` and `git log dev..HEAD --oneline` to understand what was built in the current feature branch.
+
+2. **Update `changelog.md`**:
+   - Add entries under `## [Unreleased]` with the appropriate category (`### Added`, `### Changed`, `### Fixed`)
+   - Be concise — one line per meaningful change
+   - Reference issue numbers where applicable
+
+3. **Update `project-status.md`**:
+   - Mark completed tasks as `Done` in the milestone tables
+   - Update the "Where We Left Off" section with current state
+
+4. **Update `architecture.md`** (only if needed):
+   - If new components were added, ensure they appear in the component tree
+   - If new architectural decisions were made, add to the decisions log
+   - If folder structure changed, update it
+   - Skip this if no structural changes were made
+
+5. **Commit the doc updates**:
+   - Stage only the doc files: `changelog.md`, `project-status.md`, `architecture.md`
+   - Commit with message: `docs: update living docs for [brief description]`
+
+## Rules
+- Do NOT modify any source code — only documentation files
+- Do NOT invent changes that didn't happen — only document what `git diff` shows
+- Keep entries concise — one line per change
+- Always reference issue numbers when known

--- a/changelog.md
+++ b/changelog.md
@@ -10,3 +10,10 @@
 - CLAUDE.md with project context, git rules, and team assignments
 - Architecture documentation (`architecture.md`)
 - Project status tracking (`project-status.md`)
+- SlideCanvas with 16:9 aspect ratio and responsive CSS scaling (#1)
+- CanvasElement with drag and resize via react-rnd (#2)
+- TextBlock with inline contentEditable editing (#3)
+- ImageBlock with file upload to data URL (#4)
+- ShapeBlock supporting rectangle, circle, and triangle (#5)
+- Toolbar with add text/image/shape and delete element actions (#6)
+- Slash commands for team workflow (start-issue, submit-pr, update-docs)

--- a/project-status.md
+++ b/project-status.md
@@ -1,6 +1,6 @@
 # SlideForge — Project Status
 
-## Current Phase: Setup (Phase 2)
+## Current Phase: Editor Core (Milestone 1)
 
 ## Milestone 1 — Editor Core (Day 1)
 
@@ -8,12 +8,12 @@
 |------|--------|-------|
 | Project scaffold (Next.js + Tailwind + Zustand + react-rnd) | Done | Tech Lead |
 | TypeScript types and Zustand store with all actions | Not Started | Tech Lead |
-| SlideCanvas with 16:9 aspect ratio and scaling | Not Started | Dev 1 |
-| CanvasElement with drag and resize (react-rnd) | Not Started | Dev 1 |
-| TextBlock with inline contentEditable editing | Not Started | Dev 1 |
-| ImageBlock with file upload to data URL | Not Started | Dev 1 |
-| ShapeBlock (rectangle, circle, triangle) | Not Started | Dev 1 |
-| Toolbar — add text / image / shape, delete element | Not Started | Dev 1 |
+| SlideCanvas with 16:9 aspect ratio and scaling | Done | Dev 1 |
+| CanvasElement with drag and resize (react-rnd) | Done | Dev 1 |
+| TextBlock with inline contentEditable editing | Done | Dev 1 |
+| ImageBlock with file upload to data URL | Done | Dev 1 |
+| ShapeBlock (rectangle, circle, triangle) | Done | Dev 1 |
+| Toolbar — add text / image / shape, delete element | Done | Dev 1 |
 | SlidePanel — add / delete / select / reorder slides | Not Started | Dev 2 |
 
 ## Milestone 2 — Present + Polish (Day 2)
@@ -32,4 +32,6 @@
 
 ## Where We Left Off
 
-- Phase 2 (Setup) in progress — scaffold complete, creating setup files
+- Milestone 1 in progress — editor core components (SlideCanvas, CanvasElement, TextBlock, ImageBlock, ShapeBlock, Toolbar) implemented by Dev 1
+- Remaining for Milestone 1: TypeScript types + Zustand store (Tech Lead), SlidePanel (Dev 2)
+- Feature branch `feature/1-slide-canvas` ready for PR review

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,26 +1,18 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
+  --background: #f1f5f9;
   --foreground: #171717;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+  overflow: hidden;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,65 +1,16 @@
-import Image from "next/image";
+"use client";
+
+import Toolbar from "@/components/Toolbar";
+import SlideCanvas from "@/components/SlideCanvas";
 
 export default function Home() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
-          </p>
-        </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
-        </div>
-      </main>
+    <div className="h-screen w-screen flex flex-col">
+      <Toolbar />
+      <div className="flex-1 flex overflow-hidden">
+        {/* SlidePanel will go here (Dev 2) */}
+        <SlideCanvas />
+      </div>
     </div>
   );
 }

--- a/src/components/CanvasElement.tsx
+++ b/src/components/CanvasElement.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Rnd } from "react-rnd";
+import { useSlideStore } from "@/store/useSlideStore";
+import type { SlideElement } from "@/types";
+
+interface CanvasElementProps {
+  element: SlideElement;
+  slideId: string;
+  isSelected: boolean;
+  children: React.ReactNode;
+}
+
+export default function CanvasElement({
+  element,
+  slideId,
+  isSelected,
+  children,
+}: CanvasElementProps) {
+  const updateElement = useSlideStore((s) => s.updateElement);
+  const selectElement = useSlideStore((s) => s.selectElement);
+  const pushHistory = useSlideStore((s) => s.pushHistory);
+
+  return (
+    <Rnd
+      size={{ width: element.width, height: element.height }}
+      position={{ x: element.x, y: element.y }}
+      onDragStop={(_e, d) => {
+        updateElement(slideId, element.id, { x: d.x, y: d.y });
+        pushHistory();
+      }}
+      onResizeStop={(_e, _direction, ref, _delta, position) => {
+        updateElement(slideId, element.id, {
+          width: parseInt(ref.style.width),
+          height: parseInt(ref.style.height),
+          x: position.x,
+          y: position.y,
+        });
+        pushHistory();
+      }}
+      onMouseDown={(e) => {
+        e.stopPropagation();
+        selectElement(element.id);
+      }}
+      style={{ zIndex: element.zIndex }}
+      bounds="parent"
+      className={`${isSelected ? "ring-2 ring-blue-500" : ""}`}
+    >
+      <div className="w-full h-full">{children}</div>
+    </Rnd>
+  );
+}

--- a/src/components/ImageBlock.tsx
+++ b/src/components/ImageBlock.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import type { SlideElement } from "@/types";
+
+interface ImageBlockProps {
+  element: SlideElement;
+}
+
+export default function ImageBlock({ element }: ImageBlockProps) {
+  return (
+    <div className="w-full h-full overflow-hidden" style={{ cursor: "move" }}>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={element.content}
+        alt="Slide element"
+        className="w-full h-full"
+        style={{
+          objectFit: "contain",
+          opacity: element.style.opacity ?? 1,
+          borderRadius: element.style.borderRadius || 0,
+        }}
+        draggable={false}
+      />
+    </div>
+  );
+}

--- a/src/components/ShapeBlock.tsx
+++ b/src/components/ShapeBlock.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import type { SlideElement } from "@/types";
+
+interface ShapeBlockProps {
+  element: SlideElement;
+}
+
+export default function ShapeBlock({ element }: ShapeBlockProps) {
+  const shapeType = element.content;
+  const {
+    backgroundColor = "#3b82f6",
+    opacity = 1,
+    borderRadius = 0,
+  } = element.style;
+
+  if (shapeType === "triangle") {
+    return (
+      <div
+        className="w-full h-full flex items-center justify-center"
+        style={{ cursor: "move" }}
+      >
+        <div
+          className="w-full h-full"
+          style={{
+            opacity,
+            clipPath: "polygon(50% 0%, 0% 100%, 100% 100%)",
+            backgroundColor,
+          }}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="w-full h-full"
+      style={{
+        backgroundColor,
+        opacity,
+        borderRadius: shapeType === "circle" ? "50%" : borderRadius,
+        cursor: "move",
+      }}
+    />
+  );
+}

--- a/src/components/SlideCanvas.tsx
+++ b/src/components/SlideCanvas.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useRef, useEffect, useState, useCallback } from "react";
+import { useSlideStore } from "@/store/useSlideStore";
+import { CANVAS_WIDTH, CANVAS_HEIGHT } from "@/lib/utils";
+import CanvasElement from "./CanvasElement";
+import TextBlock from "./TextBlock";
+import ImageBlock from "./ImageBlock";
+import ShapeBlock from "./ShapeBlock";
+
+export default function SlideCanvas() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(1);
+
+  const slides = useSlideStore((s) => s.slides);
+  const currentSlideIndex = useSlideStore((s) => s.currentSlideIndex);
+  const selectedElementId = useSlideStore((s) => s.selectedElementId);
+  const selectElement = useSlideStore((s) => s.selectElement);
+
+  const currentSlide = slides[currentSlideIndex];
+
+  const updateScale = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const padding = 40;
+    const availableWidth = container.clientWidth - padding * 2;
+    const availableHeight = container.clientHeight - padding * 2;
+
+    const scaleX = availableWidth / CANVAS_WIDTH;
+    const scaleY = availableHeight / CANVAS_HEIGHT;
+    setScale(Math.min(scaleX, scaleY));
+  }, []);
+
+  useEffect(() => {
+    updateScale();
+    window.addEventListener("resize", updateScale);
+    return () => window.removeEventListener("resize", updateScale);
+  }, [updateScale]);
+
+  const handleCanvasClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      selectElement(null);
+    }
+  };
+
+  const renderElement = (element: (typeof currentSlide.elements)[0]) => {
+    const isSelected = selectedElementId === element.id;
+
+    return (
+      <CanvasElement
+        key={element.id}
+        element={element}
+        slideId={currentSlide.id}
+        isSelected={isSelected}
+      >
+        {element.type === "text" && (
+          <TextBlock
+            element={element}
+            slideId={currentSlide.id}
+            isSelected={isSelected}
+          />
+        )}
+        {element.type === "image" && <ImageBlock element={element} />}
+        {element.type === "shape" && <ShapeBlock element={element} />}
+      </CanvasElement>
+    );
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className="flex-1 flex items-center justify-center bg-slate-200 overflow-hidden"
+    >
+      <div
+        className="relative shadow-2xl"
+        style={{
+          width: CANVAS_WIDTH,
+          height: CANVAS_HEIGHT,
+          transform: `scale(${scale})`,
+          transformOrigin: "center center",
+          backgroundColor: currentSlide?.background || "#ffffff",
+        }}
+        onClick={handleCanvasClick}
+      >
+        {currentSlide?.elements.map(renderElement)}
+      </div>
+    </div>
+  );
+}

--- a/src/components/TextBlock.tsx
+++ b/src/components/TextBlock.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { useSlideStore } from "@/store/useSlideStore";
+import type { SlideElement } from "@/types";
+
+interface TextBlockProps {
+  element: SlideElement;
+  slideId: string;
+  isSelected: boolean;
+}
+
+export default function TextBlock({
+  element,
+  slideId,
+  isSelected,
+}: TextBlockProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const updateElement = useSlideStore((s) => s.updateElement);
+  const pushHistory = useSlideStore((s) => s.pushHistory);
+
+  useEffect(() => {
+    if (isEditing && contentRef.current) {
+      contentRef.current.focus();
+    }
+  }, [isEditing]);
+
+  useEffect(() => {
+    if (!isSelected) {
+      setIsEditing(false);
+    }
+  }, [isSelected]);
+
+  const handleDoubleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setIsEditing(true);
+  };
+
+  const handleBlur = () => {
+    if (contentRef.current) {
+      const newContent = contentRef.current.innerText;
+      if (newContent !== element.content) {
+        updateElement(slideId, element.id, { content: newContent });
+        pushHistory();
+      }
+    }
+    setIsEditing(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      contentRef.current?.blur();
+    }
+    e.stopPropagation();
+  };
+
+  return (
+    <div
+      className="w-full h-full flex items-center justify-center"
+      onDoubleClick={handleDoubleClick}
+      style={{ cursor: isEditing ? "text" : "move" }}
+    >
+      <div
+        ref={contentRef}
+        contentEditable={isEditing}
+        suppressContentEditableWarning
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+        className="w-full h-full flex items-center outline-none"
+        style={{
+          fontSize: element.style.fontSize || 32,
+          fontWeight: element.style.fontWeight || "normal",
+          color: element.style.color || "#1a1a1a",
+          backgroundColor: element.style.backgroundColor || "transparent",
+          textAlign: element.style.textAlign || "center",
+          opacity: element.style.opacity ?? 1,
+          justifyContent:
+            element.style.textAlign === "left"
+              ? "flex-start"
+              : element.style.textAlign === "right"
+                ? "flex-end"
+                : "center",
+          padding: "8px",
+        }}
+      >
+        {element.content}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { useSlideStore } from "@/store/useSlideStore";
+import {
+  Type,
+  Image,
+  Square,
+  Circle,
+  Triangle,
+  Trash2,
+  Play,
+  ChevronDown,
+} from "lucide-react";
+
+export default function Toolbar() {
+  const addTextElement = useSlideStore((s) => s.addTextElement);
+  const addImageElement = useSlideStore((s) => s.addImageElement);
+  const addShapeElement = useSlideStore((s) => s.addShapeElement);
+  const deleteElement = useSlideStore((s) => s.deleteElement);
+  const selectedElementId = useSlideStore((s) => s.selectedElementId);
+  const startPresenting = useSlideStore((s) => s.startPresenting);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [showShapeMenu, setShowShapeMenu] = useState(false);
+
+  const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      const dataUrl = event.target?.result as string;
+      addImageElement(dataUrl);
+    };
+    reader.readAsDataURL(file);
+
+    e.target.value = "";
+  };
+
+  const handleAddShape = (shapeType: string) => {
+    addShapeElement(shapeType);
+    setShowShapeMenu(false);
+  };
+
+  return (
+    <div className="h-14 bg-white border-b border-slate-200 flex items-center px-4 gap-2 shrink-0">
+      <span className="font-semibold text-slate-800 mr-4 text-lg">
+        SlideForge
+      </span>
+
+      <div className="w-px h-8 bg-slate-200" />
+
+      <button
+        onClick={addTextElement}
+        className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-100 rounded-md transition-colors"
+        title="Add Text"
+      >
+        <Type size={16} />
+        Text
+      </button>
+
+      <button
+        onClick={() => fileInputRef.current?.click()}
+        className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-100 rounded-md transition-colors"
+        title="Add Image"
+      >
+        <Image size={16} />
+        Image
+      </button>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        onChange={handleImageUpload}
+        className="hidden"
+      />
+
+      <div className="relative">
+        <button
+          onClick={() => setShowShapeMenu(!showShapeMenu)}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-100 rounded-md transition-colors"
+          title="Add Shape"
+        >
+          <Square size={16} />
+          Shape
+          <ChevronDown size={14} />
+        </button>
+        {showShapeMenu && (
+          <div className="absolute top-full left-0 mt-1 bg-white border border-slate-200 rounded-md shadow-lg z-50">
+            <button
+              onClick={() => handleAddShape("rectangle")}
+              className="flex items-center gap-2 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100 w-full"
+            >
+              <Square size={14} /> Rectangle
+            </button>
+            <button
+              onClick={() => handleAddShape("circle")}
+              className="flex items-center gap-2 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100 w-full"
+            >
+              <Circle size={14} /> Circle
+            </button>
+            <button
+              onClick={() => handleAddShape("triangle")}
+              className="flex items-center gap-2 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100 w-full"
+            >
+              <Triangle size={14} /> Triangle
+            </button>
+          </div>
+        )}
+      </div>
+
+      <div className="w-px h-8 bg-slate-200" />
+
+      <button
+        onClick={() => selectedElementId && deleteElement(selectedElementId)}
+        disabled={!selectedElementId}
+        className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-slate-700 hover:bg-red-50 hover:text-red-600 rounded-md transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        title="Delete Element"
+      >
+        <Trash2 size={16} />
+        Delete
+      </button>
+
+      <div className="flex-1" />
+
+      <button
+        onClick={startPresenting}
+        className="flex items-center gap-1.5 px-4 py-1.5 text-sm text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors"
+        title="Present"
+      >
+        <Play size={16} />
+        Present
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **SlideCanvas**: 16:9 canvas with CSS `transform: scale()` responsive sizing (1920x1080 virtual space)
- **CanvasElement**: react-rnd wrapper for drag/resize with selection ring and history push
- **TextBlock**: contentEditable inline text editing (double-click to edit, Escape to exit)
- **ImageBlock**: renders data URL images with opacity/borderRadius support
- **ShapeBlock**: rectangle, circle (border-radius), triangle (clip-path)
- **Toolbar**: add text/image/shape, delete selected element, present button
- Cleaned up default Next.js boilerplate in page.tsx and globals.css

## Issues
Closes #1, #2, #3, #4, #5, #6

## Test plan
- [ ] Canvas renders at 16:9 and scales responsively on window resize
- [ ] Click "Text" → text element appears → drag to reposition → resize via handles
- [ ] Double-click text → edit inline → click outside to save
- [ ] Click "Image" → upload file → image appears on canvas
- [ ] Click Shape → pick rectangle/circle/triangle → shape renders correctly
- [ ] Click element → blue selection ring → click "Delete" → element removed
- [ ] Click empty canvas → deselects element

🤖 Generated with [Claude Code](https://claude.com/claude-code)