### PR TITLE
feat: add SlidePanel with slide thumbnails and management (#7)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,3 +17,5 @@
 - ShapeBlock supporting rectangle, circle, and triangle (#5)
 - Toolbar with add text/image/shape and delete element actions (#6)
 - Slash commands for team workflow (start-issue, submit-pr, update-docs)
+- SlidePanel left sidebar with slide thumbnails, add/delete/reorder (#7)
+- SlideThumbnail with mini CSS-scaled slide preview and slide numbers (#7)

--- a/project-status.md
+++ b/project-status.md
@@ -14,7 +14,7 @@
 | ImageBlock with file upload to data URL | Done | Dev 1 |
 | ShapeBlock (rectangle, circle, triangle) | Done | Dev 1 |
 | Toolbar — add text / image / shape, delete element | Done | Dev 1 |
-| SlidePanel — add / delete / select / reorder slides | Not Started | Dev 2 |
+| SlidePanel — add / delete / select / reorder slides | Done | Dev 2 |
 
 ## Milestone 2 — Present + Polish (Day 2)
 
@@ -32,6 +32,6 @@
 
 ## Where We Left Off
 
-- Milestone 1 in progress — editor core components (SlideCanvas, CanvasElement, TextBlock, ImageBlock, ShapeBlock, Toolbar) implemented by Dev 1
-- Remaining for Milestone 1: TypeScript types + Zustand store (Tech Lead), SlidePanel (Dev 2)
-- Feature branch `feature/1-slide-canvas` ready for PR review
+- Milestone 1 complete — all editor core components implemented
+- SlidePanel with thumbnails, add/delete/reorder slides implemented by Dev 2
+- Ready to start Milestone 2 (Present + Polish)

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,13 +2,14 @@
 
 import Toolbar from "@/components/Toolbar";
 import SlideCanvas from "@/components/SlideCanvas";
+import SlidePanel from "@/components/SlidePanel";
 
 export default function Home() {
   return (
     <div className="h-screen w-screen flex flex-col">
       <Toolbar />
       <div className="flex-1 flex overflow-hidden">
-        {/* SlidePanel will go here (Dev 2) */}
+        <SlidePanel />
         <SlideCanvas />
       </div>
     </div>

--- a/src/components/SlidePanel.tsx
+++ b/src/components/SlidePanel.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useRef } from "react";
+import { Plus } from "lucide-react";
+import { useSlideStore } from "@/store/useSlideStore";
+import SlideThumbnail from "./SlideThumbnail";
+
+export default function SlidePanel() {
+  const slides = useSlideStore((s) => s.slides);
+  const currentSlideIndex = useSlideStore((s) => s.currentSlideIndex);
+  const addSlide = useSlideStore((s) => s.addSlide);
+  const deleteSlide = useSlideStore((s) => s.deleteSlide);
+  const setCurrentSlide = useSlideStore((s) => s.setCurrentSlide);
+  const reorderSlides = useSlideStore((s) => s.reorderSlides);
+
+  const dragIndexRef = useRef<number | null>(null);
+
+  const handleDragStart = (index: number) => (e: React.DragEvent) => {
+    dragIndexRef.current = index;
+    e.dataTransfer.effectAllowed = "move";
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+  };
+
+  const handleDrop = (toIndex: number) => (e: React.DragEvent) => {
+    e.preventDefault();
+    const fromIndex = dragIndexRef.current;
+    if (fromIndex !== null && fromIndex !== toIndex) {
+      reorderSlides(fromIndex, toIndex);
+    }
+    dragIndexRef.current = null;
+  };
+
+  return (
+    <div className="w-56 bg-slate-100 border-r border-slate-300 flex flex-col">
+      <div className="flex-1 overflow-y-auto p-3 space-y-3">
+        {slides.map((slide, index) => (
+          <SlideThumbnail
+            key={slide.id}
+            slide={slide}
+            index={index}
+            isActive={index === currentSlideIndex}
+            canDelete={slides.length > 1}
+            onClick={() => setCurrentSlide(index)}
+            onDelete={() => deleteSlide(slide.id)}
+            onDragStart={handleDragStart(index)}
+            onDragOver={handleDragOver}
+            onDrop={handleDrop(index)}
+          />
+        ))}
+      </div>
+      <div className="p-3 border-t border-slate-300">
+        <button
+          onClick={addSlide}
+          className="w-full flex items-center justify-center gap-1.5 py-2 rounded bg-blue-500 text-white text-sm font-medium hover:bg-blue-600 transition-colors"
+        >
+          <Plus size={16} />
+          Add Slide
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SlideThumbnail.tsx
+++ b/src/components/SlideThumbnail.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { Trash2 } from "lucide-react";
+import type { Slide } from "@/types";
+import { CANVAS_WIDTH, CANVAS_HEIGHT } from "@/lib/utils";
+import TextBlock from "./TextBlock";
+import ImageBlock from "./ImageBlock";
+import ShapeBlock from "./ShapeBlock";
+
+const THUMBNAIL_WIDTH = 192;
+const THUMBNAIL_SCALE = THUMBNAIL_WIDTH / CANVAS_WIDTH;
+
+interface SlideThumbnailProps {
+  slide: Slide;
+  index: number;
+  isActive: boolean;
+  canDelete: boolean;
+  onClick: () => void;
+  onDelete: () => void;
+  onDragStart: (e: React.DragEvent) => void;
+  onDragOver: (e: React.DragEvent) => void;
+  onDrop: (e: React.DragEvent) => void;
+}
+
+export default function SlideThumbnail({
+  slide,
+  index,
+  isActive,
+  canDelete,
+  onClick,
+  onDelete,
+  onDragStart,
+  onDragOver,
+  onDrop,
+}: SlideThumbnailProps) {
+  const handleDelete = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onDelete();
+  };
+
+  return (
+    <div
+      className="group relative cursor-pointer"
+      draggable
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      onClick={onClick}
+    >
+      <div className="flex items-start gap-2">
+        <span className="text-xs text-slate-400 mt-1 w-4 text-right shrink-0">
+          {index + 1}
+        </span>
+        <div
+          className={`relative overflow-hidden rounded border-2 transition-colors ${
+            isActive
+              ? "border-blue-500 shadow-md"
+              : "border-slate-300 hover:border-slate-400"
+          }`}
+          style={{
+            width: THUMBNAIL_WIDTH,
+            height: THUMBNAIL_WIDTH * (CANVAS_HEIGHT / CANVAS_WIDTH),
+          }}
+        >
+          {/* Scaled-down slide render */}
+          <div
+            className="absolute top-0 left-0 origin-top-left"
+            style={{
+              width: CANVAS_WIDTH,
+              height: CANVAS_HEIGHT,
+              transform: `scale(${THUMBNAIL_SCALE})`,
+              backgroundColor: slide.background || "#ffffff",
+            }}
+          >
+            {slide.elements.map((element) => (
+              <div
+                key={element.id}
+                className="absolute"
+                style={{
+                  left: element.x,
+                  top: element.y,
+                  width: element.width,
+                  height: element.height,
+                  zIndex: element.zIndex,
+                }}
+              >
+                {element.type === "text" && (
+                  <TextBlock
+                    element={element}
+                    slideId={slide.id}
+                    isSelected={false}
+                  />
+                )}
+                {element.type === "image" && <ImageBlock element={element} />}
+                {element.type === "shape" && <ShapeBlock element={element} />}
+              </div>
+            ))}
+          </div>
+
+          {/* Delete button */}
+          {canDelete && (
+            <button
+              onClick={handleDelete}
+              className="absolute top-1 right-1 p-0.5 rounded bg-red-500 text-white opacity-0 group-hover:opacity-100 transition-opacity hover:bg-red-600 z-10"
+            >
+              <Trash2 size={12} />
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **SlidePanel** — left sidebar (224px) with scrollable list of slide thumbnails and "Add Slide" button
- **SlideThumbnail** — mini CSS-scaled preview of each slide (1920×1080 → 192px wide), with slide number, active highlight, and hover delete button
- Wired into `page.tsx` layout replacing the placeholder comment
- Drag-to-reorder via HTML Drag and Drop API (no extra dependencies)

Closes #7

## Test plan
- [ ] Click "Add Slide" — new slide appears in panel and becomes active
- [ ] Click a thumbnail — canvas switches to that slide
- [ ] Active slide has blue border highlight
- [ ] Hover over thumbnail — red delete button appears
- [ ] Delete a slide — removed from panel, cannot delete last slide
- [ ] Drag a thumbnail to reorder — slides reorder correctly
- [ ] Thumbnails render mini previews of slide content (text, shapes, images)
- [ ] Slide numbers display correctly and update after reorder

🤖 Generated with [Claude Code](https://claude.com/claude-code)