### PR TITLE
feat: add PresentationMode, slide transitions, and ThemePicker

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -18,7 +18,7 @@ App (page.tsx)
 │           ├── ImageBlock
 │           └── ShapeBlock
 ├── StylePanel           — element properties (font, color, opacity)
-└── PresentationMode     — fullscreen overlay with keyboard navigation
+└── PresentationMode     — fullscreen overlay with keyboard nav, CSS transitions
 ```
 
 ## State Management
@@ -40,6 +40,14 @@ The editor canvas represents a virtual 1920x1080 space. It scales to fit the edi
 
 All element positions (x, y, width, height) are stored in virtual canvas units, not screen pixels.
 
+## Presentation Mode
+
+PresentationMode renders as a fixed fullscreen overlay (`z-[9999]`). It uses the Fullscreen API to enter browser fullscreen. The current slide is scaled to fill the viewport while maintaining 16:9 aspect ratio (black bars on mismatched screens). Navigation via keyboard (arrows, space, escape) and click (left/right half). Slide transitions use CSS `@keyframes` animations (fade or slide-left, toggled with T key), triggered by changing the React `key` on slide change.
+
+## Theme Picker
+
+ThemePicker is a dropdown in the Toolbar. It offers 4 preset themes (Light, Dark, Ocean, Warm) defined in `src/lib/defaults.ts`. Applying a theme sets the slide background and updates all text element colors. Background-only swatches are also available for quick changes.
+
 ## Slide Thumbnails
 
 Thumbnails are rendered by wrapping the actual slide content in a container with `transform: scale(0.15)` and `overflow: hidden`. No separate canvas rendering.
@@ -54,6 +62,7 @@ src/
 │   └── globals.css
 ├── components/
 │   ├── Toolbar.tsx
+│   ├── ThemePicker.tsx
 │   ├── SlidePanel.tsx
 │   ├── SlideThumbnail.tsx
 │   ├── SlideCanvas.tsx
@@ -82,3 +91,5 @@ src/
 | Canvas approach | HTML + CSS transform | Easier than Canvas API, native text editing works |
 | Image storage | Data URLs | No server needed, simple but limits file sizes |
 | Thumbnails | CSS scale transform | No separate rendering pass needed |
+| Slide transitions | CSS @keyframes | No animation library needed, lightweight |
+| Presentation scaling | Same CSS scale approach | Consistent with editor canvas scaling |

--- a/changelog.md
+++ b/changelog.md
@@ -19,3 +19,6 @@
 - Slash commands for team workflow (start-issue, submit-pr, update-docs)
 - SlidePanel left sidebar with slide thumbnails, add/delete/reorder (#7)
 - SlideThumbnail with mini CSS-scaled slide preview and slide numbers (#7)
+- PresentationMode with fullscreen, keyboard/click navigation, slide counter (#8)
+- Slide transitions: fade and slide-left with CSS keyframe animations (#9)
+- ThemePicker with 4 preset themes and background color swatches (#10)

--- a/project-status.md
+++ b/project-status.md
@@ -1,6 +1,6 @@
 # SlideForge — Project Status
 
-## Current Phase: Editor Core (Milestone 1)
+## Current Phase: Present + Polish (Milestone 2)
 
 ## Milestone 1 — Editor Core (Day 1)
 
@@ -20,9 +20,9 @@
 
 | Task | Status | Owner |
 |------|--------|-------|
-| PresentationMode — fullscreen, keyboard navigation | Not Started | Dev 2 |
-| Slide transitions (fade, slide-left via CSS) | Not Started | Dev 2 |
-| Background / theme picker (3-4 presets) | Not Started | Dev 2 |
+| PresentationMode — fullscreen, keyboard navigation | Done | Dev 2 |
+| Slide transitions (fade, slide-left via CSS) | Done | Dev 2 |
+| Background / theme picker (3-4 presets) | Done | Dev 2 |
 | StylePanel — font size, color, weight, opacity, alignment | Not Started | Tech Lead |
 | Element z-ordering (bring forward / send back) | Not Started | Tech Lead |
 | Undo / redo (Zustand temporal middleware) | Not Started | Tech Lead |
@@ -33,5 +33,5 @@
 ## Where We Left Off
 
 - Milestone 1 complete — all editor core components implemented
-- SlidePanel with thumbnails, add/delete/reorder slides implemented by Dev 2
-- Ready to start Milestone 2 (Present + Polish)
+- Dev 2 day 2 tasks complete: PresentationMode, transitions, ThemePicker
+- Remaining: StylePanel, z-ordering, undo/redo, keyboard shortcuts, polish, deploy

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import Toolbar from "@/components/Toolbar";
 import SlideCanvas from "@/components/SlideCanvas";
 import SlidePanel from "@/components/SlidePanel";
+import PresentationMode from "@/components/PresentationMode";
 
 export default function Home() {
   return (
@@ -12,6 +13,7 @@ export default function Home() {
         <SlidePanel />
         <SlideCanvas />
       </div>
+      <PresentationMode />
     </div>
   );
 }

--- a/src/components/PresentationMode.tsx
+++ b/src/components/PresentationMode.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useEffect, useRef, useState, useCallback } from "react";
+import { useSlideStore } from "@/store/useSlideStore";
+import { CANVAS_WIDTH, CANVAS_HEIGHT } from "@/lib/utils";
+import TextBlock from "./TextBlock";
+import ImageBlock from "./ImageBlock";
+import ShapeBlock from "./ShapeBlock";
+
+type Transition = "fade" | "slide-left";
+
+export default function PresentationMode() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(1);
+  const [transition, setTransition] = useState<Transition>("fade");
+  const [slideKey, setSlideKey] = useState(0);
+  const [prevIndex, setPrevIndex] = useState(0);
+
+  const slides = useSlideStore((s) => s.slides);
+  const currentSlideIndex = useSlideStore((s) => s.currentSlideIndex);
+  const isPresenting = useSlideStore((s) => s.isPresenting);
+  const stopPresenting = useSlideStore((s) => s.stopPresenting);
+  const nextSlide = useSlideStore((s) => s.nextSlide);
+  const prevSlide = useSlideStore((s) => s.prevSlide);
+
+  const currentSlide = slides[currentSlideIndex];
+
+  // Track slide changes for animation key — derive from state
+  if (prevIndex !== currentSlideIndex) {
+    setPrevIndex(currentSlideIndex);
+    setSlideKey((k) => k + 1);
+  }
+
+  // Enter fullscreen when presenting starts
+  useEffect(() => {
+    if (!isPresenting) return;
+
+    const enterFullscreen = async () => {
+      try {
+        await document.documentElement.requestFullscreen();
+      } catch {
+        // Fullscreen may not be available
+      }
+    };
+    enterFullscreen();
+
+    return () => {
+      if (document.fullscreenElement) {
+        document.exitFullscreen().catch(() => {});
+      }
+    };
+  }, [isPresenting]);
+
+  // Exit presentation when fullscreen is exited externally
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      if (!document.fullscreenElement && isPresenting) {
+        stopPresenting();
+      }
+    };
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+    return () =>
+      document.removeEventListener("fullscreenchange", handleFullscreenChange);
+  }, [isPresenting, stopPresenting]);
+
+  // Scale canvas to fill viewport while maintaining 16:9
+  const updateScale = useCallback(() => {
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    const scaleX = vw / CANVAS_WIDTH;
+    const scaleY = vh / CANVAS_HEIGHT;
+    setScale(Math.min(scaleX, scaleY));
+  }, []);
+
+  useEffect(() => {
+    if (!isPresenting) return;
+    // Subscribe to resize events
+    const handler = () => updateScale();
+    handler();
+    window.addEventListener("resize", handler);
+    return () => window.removeEventListener("resize", handler);
+  }, [isPresenting, updateScale]);
+
+  // Keyboard navigation
+  useEffect(() => {
+    if (!isPresenting) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      switch (e.key) {
+        case "ArrowRight":
+        case "ArrowDown":
+        case " ":
+          e.preventDefault();
+          nextSlide();
+          break;
+        case "ArrowLeft":
+        case "ArrowUp":
+          e.preventDefault();
+          prevSlide();
+          break;
+        case "Escape":
+          e.preventDefault();
+          stopPresenting();
+          break;
+        case "t":
+        case "T":
+          setTransition((prev) =>
+            prev === "fade" ? "slide-left" : "fade"
+          );
+          break;
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isPresenting, nextSlide, prevSlide, stopPresenting]);
+
+  if (!isPresenting || !currentSlide) return null;
+
+  const fadeAnimation = `
+    @keyframes presentFadeIn {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+    @keyframes presentSlideIn {
+      from { transform: scale(${scale}) translateX(50%); opacity: 0; }
+      to { transform: scale(${scale}) translateX(0); opacity: 1; }
+    }
+  `;
+
+  const animationStyle: React.CSSProperties =
+    transition === "fade"
+      ? {
+          transform: `scale(${scale})`,
+          animation: "presentFadeIn 400ms ease-in-out",
+        }
+      : {
+          animation: "presentSlideIn 400ms ease-in-out",
+          transform: `scale(${scale})`,
+        };
+
+  return (
+    <div
+      ref={containerRef}
+      className="fixed inset-0 z-[9999] bg-black flex items-center justify-center overflow-hidden cursor-none"
+      onClick={(e) => {
+        const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+        if (e.clientX > rect.width / 2) {
+          nextSlide();
+        } else {
+          prevSlide();
+        }
+      }}
+    >
+      <style>{fadeAnimation}</style>
+      <div
+        key={slideKey}
+        className="relative"
+        style={{
+          width: CANVAS_WIDTH,
+          height: CANVAS_HEIGHT,
+          backgroundColor: currentSlide.background || "#ffffff",
+          transformOrigin: "center center",
+          ...animationStyle,
+        }}
+      >
+        {currentSlide.elements.map((element) => (
+          <div
+            key={element.id}
+            className="absolute"
+            style={{
+              left: element.x,
+              top: element.y,
+              width: element.width,
+              height: element.height,
+              zIndex: element.zIndex,
+              transform: element.rotation
+                ? `rotate(${element.rotation}deg)`
+                : undefined,
+            }}
+          >
+            {element.type === "text" && (
+              <TextBlock
+                element={element}
+                slideId={currentSlide.id}
+                isSelected={false}
+                readOnly
+              />
+            )}
+            {element.type === "image" && <ImageBlock element={element} />}
+            {element.type === "shape" && <ShapeBlock element={element} />}
+          </div>
+        ))}
+      </div>
+
+      {/* Slide counter */}
+      <div className="absolute bottom-4 right-6 text-white/60 text-sm font-mono select-none">
+        {currentSlideIndex + 1} / {slides.length}
+      </div>
+
+      {/* Transition indicator */}
+      <div className="absolute bottom-4 left-6 text-white/40 text-xs font-mono select-none">
+        {transition} · press T to switch
+      </div>
+    </div>
+  );
+}

--- a/src/components/TextBlock.tsx
+++ b/src/components/TextBlock.tsx
@@ -8,12 +8,14 @@ interface TextBlockProps {
   element: SlideElement;
   slideId: string;
   isSelected: boolean;
+  readOnly?: boolean;
 }
 
 export default function TextBlock({
   element,
   slideId,
   isSelected,
+  readOnly,
 }: TextBlockProps) {
   const [isEditing, setIsEditing] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -33,6 +35,7 @@ export default function TextBlock({
   }, [isSelected]);
 
   const handleDoubleClick = (e: React.MouseEvent) => {
+    if (readOnly) return;
     e.stopPropagation();
     setIsEditing(true);
   };

--- a/src/components/ThemePicker.tsx
+++ b/src/components/ThemePicker.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState } from "react";
+import { useSlideStore } from "@/store/useSlideStore";
+import { THEMES, DEFAULT_BACKGROUNDS } from "@/lib/defaults";
+import { Palette, ChevronDown } from "lucide-react";
+
+export default function ThemePicker() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const slides = useSlideStore((s) => s.slides);
+  const currentSlideIndex = useSlideStore((s) => s.currentSlideIndex);
+  const setSlideBackground = useSlideStore((s) => s.setSlideBackground);
+  const updateElement = useSlideStore((s) => s.updateElement);
+  const pushHistory = useSlideStore((s) => s.pushHistory);
+
+  const currentSlide = slides[currentSlideIndex];
+
+  const applyTheme = (theme: (typeof THEMES)[number]) => {
+    if (!currentSlide) return;
+    setSlideBackground(currentSlide.id, theme.slideBackground);
+    // Update text color for all text elements on current slide
+    currentSlide.elements
+      .filter((el) => el.type === "text")
+      .forEach((el) => {
+        updateElement(currentSlide.id, el.id, {
+          style: { ...el.style, color: theme.textColor },
+        });
+      });
+    pushHistory();
+    setIsOpen(false);
+  };
+
+  const applyBackground = (color: string) => {
+    if (!currentSlide) return;
+    setSlideBackground(currentSlide.id, color);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-100 rounded-md transition-colors"
+        title="Theme & Background"
+      >
+        <Palette size={16} />
+        Theme
+        <ChevronDown size={14} />
+      </button>
+
+      {isOpen && (
+        <>
+          <div
+            className="fixed inset-0 z-40"
+            onClick={() => setIsOpen(false)}
+          />
+          <div className="absolute top-full left-0 mt-1 bg-white border border-slate-200 rounded-lg shadow-lg z-50 w-64 p-3">
+            {/* Themes */}
+            <div className="mb-3">
+              <p className="text-xs font-medium text-slate-500 uppercase tracking-wide mb-2">
+                Themes
+              </p>
+              <div className="grid grid-cols-2 gap-2">
+                {THEMES.map((theme) => (
+                  <button
+                    key={theme.name}
+                    onClick={() => applyTheme(theme)}
+                    className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-slate-50 border border-slate-100 transition-colors"
+                  >
+                    <div
+                      className="w-6 h-6 rounded border border-slate-200 shrink-0"
+                      style={{ backgroundColor: theme.slideBackground }}
+                    />
+                    <span className="text-xs text-slate-700">{theme.name}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Background colors */}
+            <div>
+              <p className="text-xs font-medium text-slate-500 uppercase tracking-wide mb-2">
+                Background
+              </p>
+              <div className="flex gap-2 flex-wrap">
+                {DEFAULT_BACKGROUNDS.map((color) => (
+                  <button
+                    key={color}
+                    onClick={() => applyBackground(color)}
+                    className="w-8 h-8 rounded-md border-2 transition-all hover:scale-110"
+                    style={{
+                      backgroundColor: color,
+                      borderColor:
+                        currentSlide?.background === color
+                          ? "#3b82f6"
+                          : "#e2e8f0",
+                    }}
+                    title={color}
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -12,6 +12,7 @@ import {
   Play,
   ChevronDown,
 } from "lucide-react";
+import ThemePicker from "./ThemePicker";
 
 export default function Toolbar() {
   const addTextElement = useSlideStore((s) => s.addTextElement);
@@ -109,6 +110,8 @@ export default function Toolbar() {
           </div>
         )}
       </div>
+
+      <ThemePicker />
 
       <div className="w-px h-8 bg-slate-200" />
 


### PR DESCRIPTION
## Summary
- **PresentationMode** (#8): Fullscreen overlay with Fullscreen API, keyboard navigation (arrows, space, escape), click navigation (left/right half), slide counter in bottom-right
- **Slide transitions** (#9): CSS `@keyframes` fade and slide-left animations (400ms), toggled with T key during presentation
- **ThemePicker** (#10): Toolbar dropdown with 4 preset themes (Light, Dark, Ocean, Warm) and 6 background color swatches. Themes update slide background + all text element colors

Closes #8, Closes #9, Closes #10

## Test plan
- [ ] Click "Present" button — enters fullscreen presentation mode
- [ ] Arrow Right / Down / Space advances to next slide
- [ ] Arrow Left / Up goes to previous slide
- [ ] Escape exits presentation mode
- [ ] Exiting browser fullscreen also exits presentation mode
- [ ] Slide counter shows correct "X / Y" in bottom-right
- [ ] Fade transition animates on slide change
- [ ] Press T to toggle to slide-left transition, verify animation
- [ ] Click Theme dropdown in toolbar — shows themes and background swatches
- [ ] Apply "Dark" theme — slide background changes, text color updates
- [ ] Apply "Ocean" theme — verify different colors
- [ ] Click a background swatch — only background changes (not text)
- [ ] Verify active background swatch has blue border highlight
- [ ] Build passes (`bun run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)