### PR TITLE
feat: add keyboard shortcuts for undo/redo, delete, duplicate (#13, #14)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,10 +6,13 @@ import SlidePanel from "@/components/SlidePanel";
 import PresentationMode from "@/components/PresentationMode";
 import StylePanel from "@/components/StylePanel";
 import { useSlideStore } from "@/store/useSlideStore";
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 
 export default function Home() {
   const isPresenting = useSlideStore((s) => s.isPresenting);
   const selectedElementId = useSlideStore((s) => s.selectedElementId);
+
+  useKeyboardShortcuts();
 
   if (isPresenting) {
     return <PresentationMode />;

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,67 @@
+import { useEffect } from "react";
+import { useSlideStore } from "@/store/useSlideStore";
+
+function isEditingText(e: KeyboardEvent): boolean {
+  const target = e.target as HTMLElement;
+  return (
+    target.isContentEditable ||
+    target.tagName === "INPUT" ||
+    target.tagName === "TEXTAREA"
+  );
+}
+
+export function useKeyboardShortcuts() {
+  const undo = useSlideStore((s) => s.undo);
+  const redo = useSlideStore((s) => s.redo);
+  const deleteElement = useSlideStore((s) => s.deleteElement);
+  const duplicateElement = useSlideStore((s) => s.duplicateElement);
+  const selectElement = useSlideStore((s) => s.selectElement);
+  const selectedElementId = useSlideStore((s) => s.selectedElementId);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const mod = e.metaKey || e.ctrlKey;
+
+      // Undo: Ctrl/Cmd+Z (works even when editing text)
+      if (mod && !e.shiftKey && e.key === "z") {
+        e.preventDefault();
+        undo();
+        return;
+      }
+
+      // Redo: Ctrl/Cmd+Shift+Z
+      if (mod && e.shiftKey && e.key === "z") {
+        e.preventDefault();
+        redo();
+        return;
+      }
+
+      // Everything below requires NOT editing text
+      if (isEditingText(e)) return;
+
+      // Delete/Backspace: delete selected element
+      if ((e.key === "Delete" || e.key === "Backspace") && selectedElementId) {
+        e.preventDefault();
+        deleteElement(selectedElementId);
+        return;
+      }
+
+      // Ctrl/Cmd+D: duplicate selected element
+      if (mod && e.key === "d" && selectedElementId) {
+        e.preventDefault();
+        duplicateElement(selectedElementId);
+        return;
+      }
+
+      // Escape: deselect
+      if (e.key === "Escape" && selectedElementId) {
+        e.preventDefault();
+        selectElement(null);
+        return;
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [undo, redo, deleteElement, duplicateElement, selectElement, selectedElementId]);
+}


### PR DESCRIPTION
## Summary
- New `useKeyboardShortcuts` hook in `src/hooks/useKeyboardShortcuts.ts`
- **Undo/Redo (#13)**: Ctrl/Cmd+Z and Ctrl/Cmd+Shift+Z — works globally
- **Keyboard shortcuts (#14)**: Delete/Backspace (delete element), Ctrl/Cmd+D (duplicate), Escape (deselect)
- Smart guard: Delete/Backspace/Escape don't fire when user is editing text in contentEditable or input fields
- Hook wired into page.tsx

## Test plan
- [ ] Ctrl+Z undoes last action (add element, move, style change)
- [ ] Ctrl+Shift+Z redoes
- [ ] Select an element → press Delete → element removed
- [ ] Select an element → Ctrl+D → duplicate appears offset by 20px
- [ ] Select an element → press Escape → deselected
- [ ] Double-click text to edit → type → press Delete → deletes text character, NOT the element
- [ ] While editing text → Backspace works normally for text editing
- [ ] Undo/redo works even while editing text (Ctrl+Z)

Closes #13
Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)